### PR TITLE
couple quick tweaks

### DIFF
--- a/lib/gossip.ex
+++ b/lib/gossip.ex
@@ -1,4 +1,15 @@
 defmodule Gossip do
+  use Application
+
+  def start(_type, _args) do
+    import Supervisor.Spec
+
+    children = [
+      supervisor(Gossip.Supervisor, [])
+    ]
+    Supervisor.start_link(children, strategy: :one_for_one)
+  end
+
   @moduledoc """
   Gossip client
 

--- a/lib/gossip/monitor.ex
+++ b/lib/gossip/monitor.ex
@@ -5,6 +5,7 @@ defmodule Gossip.Monitor do
 
   use GenServer, restart: :permanent
 
+  @boot_delay 1_000
   @restart_delay 15_000
   @sweep_delay 30_000
 
@@ -18,7 +19,7 @@ defmodule Gossip.Monitor do
 
   def init(_) do
     Process.flag(:trap_exit, true)
-    Process.send_after(self(), :check_socket_alive, @sweep_delay)
+    Process.send_after(self(), :check_socket_alive, @boot_delay)
     {:ok, %{process: nil, online: false}}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -22,6 +22,7 @@ defmodule Gossip.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
+      mod: {Gossip, []},
       extra_applications: [:logger]
     ]
   end


### PR DESCRIPTION
Hey Eric, made a couple quick tweaks, feel free to merge or just use them for ideas or ignore this completely. Anyway two changes:

1) Turn this into an Application, this means the end user no longer needs to add anything to the supervision tree for their app, Gossip will automatically start up

2) try to connect / authenticate after a brief boot delay instead of waiting for the full sweep delay or requiring the user to manually call Gossip.start_socket

This would remove the need for documenting #1 / #3 since the end user wouldn't have to worry about either of these.